### PR TITLE
Allow `http` gem up to 5.x

### DIFF
--- a/shrine-url.gemspec
+++ b/shrine-url.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "shrine", ">= 3.0.0.rc", "< 4"
   gem.add_dependency "down", "~> 5.0"
-  gem.add_dependency "http", ">= 3.2", "< 5"
+  gem.add_dependency "http", ">= 3.2", "< 6"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "minitest"


### PR DESCRIPTION
I haven't managed to get the tests to run locally, the docker component is giving me trouble. Also there is no CI set up for this project (docker component probably a challenge there too?). 

But the only place http is used in this pretty simple codebase is:

https://github.com/shrinerb/shrine-url/blob/master/lib/shrine/storage/url.rb#L42

There's no reason for that to fail in http 5.0. Maybe another committer can easily run tests locally, to be formal about it?

If we can commit this and release a new version of shrine-url, it would allow applications using shrine-url to upgrade to the newer http 5, and avoid conflicts with any other dependencies requiring the newer http 5.